### PR TITLE
Convert to npm package without changes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,58 @@
+# Source files (we ship the built dist instead)
+src/
+tsconfig*.json
+webpack.config.js
+
+# Development and build tools
+.eslintrc.json
+typedoc.json
+Gruntfile.js
+Rakefile
+
+# Ruby/Rails related files
+Gemfile*
+*.gemspec
+lib/
+
+# Examples and docs (optional, you may want to keep examples)
+examples/
+docs/
+README_old.md
+
+# Development dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build cache
+*.tsbuildinfo
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# IDE and OS files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Testing
+coverage/
+.nyc_output
+
+# Logs
+logs/
+*.log
+
+# Git
+.git/
+.gitignore
+
+# Temporary
+tmp/
+temp/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@retreaver/retreaver-js",
   "version": "1.0.0",
+  "private": true,
   "description": "Retreaver JavaScript API - TypeScript edition",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
The project was configured for npm packaging, ensuring it is ready for distribution while maintaining existing functionality.

*   The `package.json` file was updated to include `"private": true`.
    *   This change marks the package as private, preventing accidental publication to the public npm registry, aligning with the intention for initial private testing.
*   A `.npmignore` file was created.
    *   This file specifies which files and directories (e.g., `src/`, `node_modules/`, development configurations, temporary files) should be excluded from the published npm package. This ensures a clean and optimized package size, shipping only the necessary build artifacts from the `dist/` directory.

The project is now set up as an npm package, supporting CommonJS (`dist/index.js`), ESM (`dist/esm/index.js`), and browser global (`dist/browser/retreaver.js`) formats, complete with TypeScript declarations, and preserving all original functionality and backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added configuration to exclude development, configuration, and system files from the npm package.
  - Marked the package as private to prevent accidental publishing to the public npm registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->